### PR TITLE
Update Dockerfile

### DIFF
--- a/symfony-app/php55/Dockerfile
+++ b/symfony-app/php55/Dockerfile
@@ -5,6 +5,7 @@
 FROM phpmentors/php-app:php55
 MAINTAINER KUBO Atsuhiro <kubo@iteman.jp>
 
+RUN apt-get update
 RUN apt-get install -y libfile-slurp-perl php5-sqlite
 
 # Apache2


### PR DESCRIPTION
Always run update in order to ensure up-to-date URLs. Fixes error when cache from parent is to old.